### PR TITLE
Add StateFrame actor for centralized post-sync block broadcasting

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,4 +1,4 @@
-import actors.{MDSynchronizer, RollupCoordinator, RollupSynchronizer, SyncHandler}
+import actors.{MDSynchronizer, RollupCoordinator, RollupSynchronizer, StateFrame, SyncHandler}
 import api.{BlocksApi, BlocksApiImpl, CollateralApi, CollateralApiImpl, InfoApi, InfoApiImpl, MiningApi, MiningApiImpl, PaymentsApi, PaymentsApiImpl}
 import com.google.inject.AbstractModule
 import play.api.{Configuration, Environment}
@@ -18,6 +18,7 @@ class Module(environment: Environment, configuration: Configuration) extends Abs
     bindActor(classOf[RollupCoordinator], "rollup-coordinator", p => p.withDispatcher("lithos-contexts.sync-dispatcher"))
     bindActor(classOf[SyncHandler], "sync-handler", p => p.withDispatcher("lithos-contexts.sync-dispatcher"))
     bindActor(classOf[MDSynchronizer], "md-synchronizer", p => p.withDispatcher("lithos-contexts.sync-dispatcher"))
+    bindActor(classOf[StateFrame], "state-frame", p => p.withDispatcher("lithos-contexts.sync-dispatcher"))
     bindActorFactory(classOf[RollupSynchronizer], classOf[RollupSynchronizer.RollupSyncFactory])
     bind(classOf[BlocksApi]).to(classOf[BlocksApiImpl])
     bind(classOf[CollateralApi]).to(classOf[CollateralApiImpl])

--- a/app/actors/StateFrame.scala
+++ b/app/actors/StateFrame.scala
@@ -1,0 +1,127 @@
+package actors
+
+import akka.actor.{Actor, ActorRef, Cancellable}
+import akka.pattern.ask
+import akka.util.Timeout
+import configs.{NodeConfig, SyncConfig}
+import org.ergoplatform.appkit.impl.NodeAndExplorerDataSourceImpl
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.Configuration
+import state.messages.StateFrameMessages.{Attach, Detach}
+import state.messages.SyncMessages.HandledBlock
+import state.messages.{BlockInfo, BlockMessage}
+import utils.Globals
+
+import javax.inject.Inject
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+class StateFrame @Inject()(config: Configuration) extends Actor {
+  import StateFrame._
+
+  private val logger: Logger     = LoggerFactory.getLogger("StateFrame")
+  private val syncConfig: SyncConfig = new SyncConfig(config)
+  private val nodeConfig: NodeConfig = Globals.getNodeConfig
+  private val nodeDataSource         = nodeConfig.getClient.getDataSource.asInstanceOf[NodeAndExplorerDataSourceImpl]
+
+  implicit val timeout: Timeout = Timeout(10 seconds)
+
+  override def receive: Receive = idle(Set.empty)
+
+  // No subscribers — scheduler is stopped.
+  private def idle(subscribers: Set[ActorRef]): Receive = {
+    case Attach(ref) =>
+      val startHeight = chainHeight
+      val newSubs     = subscribers + ref
+      logger.info(s"Actor ${ref.path.name} attached, starting StateFrame at height $startHeight (${newSubs.size} total)")
+      val scheduler = context.system.scheduler.scheduleWithFixedDelay(
+        syncConfig.listeningInterval,
+        syncConfig.listeningInterval,
+        self,
+        Tick
+      )(context.dispatcher)
+      context.become(running(newSubs, startHeight, scheduler))
+
+    case Detach(_) => // nothing to cancel while idle
+  }
+
+  // Scheduler running — waiting for the next Tick to arrive.
+  private def running(subscribers: Set[ActorRef], currentHeight: Int, scheduler: Cancellable): Receive = {
+    case Attach(ref) =>
+      logger.info(s"Actor ${ref.path.name} attached to StateFrame (${subscribers.size + 1} total)")
+      context.become(running(subscribers + ref, currentHeight, scheduler))
+
+    case Detach(ref) =>
+      val newSubs = subscribers - ref
+      logger.info(s"Actor ${ref.path.name} detached from StateFrame (${newSubs.size} remaining)")
+      if (newSubs.isEmpty) {
+        scheduler.cancel()
+        context.become(idle(Set.empty))
+      } else {
+        context.become(running(newSubs, currentHeight, scheduler))
+      }
+
+    case Tick =>
+      val tip = chainHeight
+      if (currentHeight <= tip) {
+        Try(fetchBlock(currentHeight)) match {
+          case Success(blockInfo) =>
+            logger.info(s"StateFrame broadcasting block at height $currentHeight to ${subscribers.size} subscriber(s)")
+            // Move to broadcasting state immediately so subsequent Ticks are dropped.
+            context.become(broadcasting(subscribers, currentHeight, scheduler))
+            val acks = subscribers.map(ref => (ref ? BlockMessage(blockInfo)).mapTo[HandledBlock])
+            Future.sequence(acks)(implicitly, context.dispatcher).onComplete {
+              case Success(_) =>
+                logger.info(s"All subscribers acknowledged block at height $currentHeight")
+                self ! AdvanceHeight(currentHeight + 1)
+              case Failure(e) =>
+                logger.error(s"One or more subscribers failed to ack block at height $currentHeight — advancing anyway", e)
+                self ! AdvanceHeight(currentHeight + 1)
+            }(context.dispatcher)
+          case Failure(e) =>
+            logger.error(s"Failed to fetch block at height $currentHeight", e)
+        }
+      }
+  }
+
+  // A broadcast is in flight — ignore ticks until every subscriber has replied.
+  private def broadcasting(subscribers: Set[ActorRef], currentHeight: Int, scheduler: Cancellable): Receive = {
+    case Tick =>
+      logger.debug(s"StateFrame ignoring tick while broadcasting block $currentHeight")
+
+    case Attach(ref) =>
+      logger.info(s"Actor ${ref.path.name} attached while broadcasting (${subscribers.size + 1} total)")
+      context.become(broadcasting(subscribers + ref, currentHeight, scheduler))
+
+    case Detach(ref) =>
+      val newSubs = subscribers - ref
+      logger.info(s"Actor ${ref.path.name} detached while broadcasting (${newSubs.size} remaining)")
+      context.become(broadcasting(newSubs, currentHeight, scheduler))
+
+    // Sent by the Future callback once all acks (or timeouts) are resolved.
+    case AdvanceHeight(nextHeight) =>
+      if (subscribers.isEmpty) {
+        scheduler.cancel()
+        context.become(idle(Set.empty))
+      } else {
+        context.become(running(subscribers, nextHeight, scheduler))
+      }
+  }
+
+  private def chainHeight: Int =
+    nodeConfig.getClient.execute(_.getHeight)
+
+  private def fetchBlock(height: Int): BlockInfo = {
+    val header = nodeDataSource.getNodeBlocksApi.getFullBlockAt(height).execute().body().get(0)
+    val block  = nodeDataSource.getNodeBlocksApi.getFullBlockById(header).execute().body()
+    BlockInfo.fromSync(block)
+  }
+}
+
+object StateFrame {
+  // Internal messages — not part of the public API.
+  private[actors] case object Tick
+  private[actors] case class AdvanceHeight(height: Int)
+}

--- a/app/state/messages/StateFrameMessages.scala
+++ b/app/state/messages/StateFrameMessages.scala
@@ -1,0 +1,8 @@
+package state.messages
+
+import akka.actor.ActorRef
+
+object StateFrameMessages {
+  case class Attach(ref: ActorRef)
+  case class Detach(ref: ActorRef)
+}

--- a/app/tasks/MDSyncTask.scala
+++ b/app/tasks/MDSyncTask.scala
@@ -18,6 +18,7 @@ import play.api.cache.SyncCacheApi
 import state.LFSMTransformer
 import state.LFSMTransformer.logger
 import state.messages.DictionaryMessages.InitialState
+import state.messages.StateFrameMessages.Attach
 import state.messages.SyncMessages._
 import state.messages.{BlockInfo, BlockMessage}
 import utils.Globals
@@ -30,7 +31,9 @@ import scala.util.{Failure, Success, Try}
 
 @Singleton
 class MDSyncTask @Inject()(cache: SyncCacheApi, system: ActorSystem, config: Configuration,
-                           @Named("md-synchronizer") mdSynchronizer: ActorRef, cs: CoordinatedShutdown) {
+                           @Named("md-synchronizer") mdSynchronizer: ActorRef,
+                           @Named("state-frame") stateFrame: ActorRef,
+                           cs: CoordinatedShutdown) {
 
   val logger: Logger = LoggerFactory.getLogger("MDSyncTask")
   val taskConfig: TaskConfiguration = new TasksConfig(config).dictionarySyncTask
@@ -60,46 +63,33 @@ class MDSyncTask @Inject()(cache: SyncCacheApi, system: ActorSystem, config: Con
               if (currentHeight != chainHeight) {
                 currentHeight = currentHeight + 1
               } else {
-                // Start listening once synced
+                // Initial sync complete — hand block delivery over to StateFrame.
                 logger.info(s"Finished syncing to height ${chainHeight}")
                 mdSynchronizer ! GetSynced
-                logger.info(s"Now listening every ${syncConfig.listeningInterval} for new blocks")
+                stateFrame ! Attach(mdSynchronizer)
+                logger.info(s"MDSynchronizer attached to StateFrame, listening every ${syncConfig.listeningInterval}")
                 Globals.setSynced()
                 if (Globals.mdDB.getDataBoxToken.isEmpty) {
                   logger.info(s"Found no data box token during sync, will continue polling" +
-                    s" blocks every ${syncConfig.listeningInterval} until data box is created")
+                    s" until data box is created")
+                  // StateFrame now delivers BlockMessages to MDSynchronizer.
+                  // This schedule only handles addToMD transforms until the data box token appears.
                   var syncTask: Option[Cancellable] = None
                   syncTask = Some(system.scheduler.scheduleWithFixedDelay(initialDelay = 10 seconds,
                     delay = syncConfig.listeningInterval)({
                     () =>
-                      // Blocking code on synchronization
-                      if (currentHeight <= chainHeight) {
-                        logger.info(s"Found new block ${currentHeight} on listen")
-                        loadBlockAsync(currentHeight, nodeDataSource).onComplete {
-                          case Failure(exception) =>
-                            logger.error(s"Failed to load block ${currentHeight} while listening", exception)
-                          case Success(block) =>
-                            logger.info(s"Successfully pre-applied block ${block.blockInfo.height}")
-                            currentHeight = currentHeight + 1
-                            if (Globals.mdDB.getDataBoxToken.isDefined) {
-                              // Cancel sync task if data box token is found
-                              logger.info(s"Ending sync task due to finding data box token ${Globals.mdDB.getDataBoxToken.get}")
-                              syncTask.get.cancel()
-                            }else if (currentHeight > chainHeight) {
-                              if (!stateConfig.disableTransforms.getOrElse(false)) {
-                                Try {
-                                  implicit val timeout = Timeout(5 seconds)
-                                  LFSMTransformer.addToMD(nodeConfig.getClient, cache, nodeConfig.getNodeWallet, stratumConfig.diff)
-                                }.recoverWith {
-                                  case t: Throwable =>
-                                    logger.error(s"Got error during sync ${t.getMessage}", t)
-                                    Failure(t)
-                                }
-                              }
-                            }
-                        }(contexts.pollingContext)
+                      if (Globals.mdDB.getDataBoxToken.isDefined) {
+                        logger.info(s"Ending sync task due to finding data box token ${Globals.mdDB.getDataBoxToken.get}")
+                        syncTask.get.cancel()
+                      } else if (!stateConfig.disableTransforms.getOrElse(false)) {
+                        Try {
+                          LFSMTransformer.addToMD(nodeConfig.getClient, cache, nodeConfig.getNodeWallet, stratumConfig.diff)
+                        }.recoverWith {
+                          case t: Throwable =>
+                            logger.error(s"Got error during sync ${t.getMessage}", t)
+                            Failure(t)
+                        }
                       }
-                    //
                   })(contexts.pollingContext))
                 } else {
                   logger.info(s"Got data box token ${Globals.mdDB.getDataBoxToken.get} during synchronization")
@@ -142,35 +132,7 @@ class MDSyncTask @Inject()(cache: SyncCacheApi, system: ActorSystem, config: Con
 
   }
 
-  private def loadBlockAsync(height: Int, dataSource: NodeAndExplorerDataSourceImpl) = {
-    implicit val context: ExecutionContext = contexts.syncContext
-    Future {
-      if (height % 100 == 0)
-        logger.info(s"Loading block at height ${height}")
-      Try {
-
-        val blockHeader = dataSource
-          .getNodeBlocksApi.getFullBlockAt(height)
-          .execute()
-          .body().get(0)
-
-        val fullBlock = dataSource
-          .getNodeBlocksApi.getFullBlockById(blockHeader)
-          .execute()
-          .body()
-        awaitBlockSync(fullBlock)
-      }
-    }.map(_.get)
-
-  }
-
   private def checkBlockTransactions(block: FullBlock): Unit = {
     mdSynchronizer ! BlockMessage(BlockInfo.fromSync(block))
-  }
-
-  private def awaitBlockSync(block: FullBlock) = {
-    implicit val timeout: Timeout = Timeout(7 seconds)
-
-    Await.result((mdSynchronizer ? BlockMessage(BlockInfo.fromSync(block))).mapTo[HandledBlock], 7 seconds)
   }
 }

--- a/app/tasks/RollupSyncTask.scala
+++ b/app/tasks/RollupSyncTask.scala
@@ -16,6 +16,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import play.api.Configuration
 import play.api.cache.{AsyncCacheApi, SyncCacheApi}
 import state.messages.{BlockInfo, BlockMessage}
+import state.messages.StateFrameMessages.Attach
 import state.messages.SyncMessages.{FullSync, GetSynced, HandledBlock, NoRollups, PartialSync, SyncMessage}
 import state.LFSMTransformer
 import stratum.ErgoStratumServer
@@ -30,7 +31,9 @@ import scala.util.{Failure, Success, Try}
 
 @Singleton
 class RollupSyncTask @Inject()(cache: SyncCacheApi, system: ActorSystem, config: Configuration,
-                               @Named("sync-handler") syncHandler: ActorRef, cs: CoordinatedShutdown) {
+                               @Named("sync-handler") syncHandler: ActorRef,
+                               @Named("state-frame") stateFrame: ActorRef,
+                               cs: CoordinatedShutdown) {
 
   val logger: Logger = LoggerFactory.getLogger("RollupSyncTask")
   val taskConfig: TaskConfiguration = new TasksConfig(config).rollupSyncTask
@@ -60,57 +63,43 @@ class RollupSyncTask @Inject()(cache: SyncCacheApi, system: ActorSystem, config:
             if (currentHeight != chainHeight) {
               currentHeight = currentHeight + 1
             } else {
-              // Start listening once synced
+              // Initial sync complete — hand block delivery over to StateFrame.
               logger.info(s"Finished syncing to height ${chainHeight}")
               syncHandler ! GetSynced
-              logger.info(s"Now listening every ${syncConfig.listeningInterval} for new blocks")
+              stateFrame ! Attach(syncHandler)
+              logger.info(s"SyncHandler attached to StateFrame, listening every ${syncConfig.listeningInterval}")
               Globals.setSynced()
+              // StateFrame now delivers BlockMessages to SyncHandler.
+              // This schedule is only responsible for triggering LFSM transforms.
               system.scheduler.scheduleWithFixedDelay(initialDelay = 10 seconds,
                 delay = syncConfig.listeningInterval)({
                 () =>
-                  // Blocking code on synchronization
-                  if (currentHeight <= chainHeight) {
-                    logger.info(s"Found new block ${currentHeight} on listen")
-                    loadBlockAsync(currentHeight, nodeDataSource).onComplete {
-                      case Failure(exception) =>
-                        logger.error(s"Failed to load block ${currentHeight} while listening", exception)
-                      case Success(block) =>
-                        logger.info(s"Successfully pre-applied block ${block.blockInfo.height}")
-                        currentHeight = currentHeight + 1
-                        if(currentHeight > chainHeight) {
-                          if(!stateConfig.disableTransforms.getOrElse(false)) {
-                            Try {
-                              implicit val timeout = Timeout(5 seconds)
-                              val msg = Await.result((syncHandler ? GetSynced).mapTo[SyncMessage], 5 seconds)
-                              msg match {
-                                case FullSync(nispTrees) =>
-                                  logger.info(s"Got FullSync() state with ${nispTrees.size} rollups")
-
-                                  LFSMTransformer.onSync(nodeConfig.getClient, cache,
-                                    nodeConfig.getNodeWallet, stratumConfig.diff, nispTrees, syncHandler, stateConfig.autoCommit.getOrElse(true))
-                                case PartialSync(syncedTrees, unsyncedIds) =>
-                                  logger.info(s"Got PartialSync() state with ${syncedTrees.size} synced rollups" +
-                                    s" and ${unsyncedIds.size} unsynced rollups")
-
-                                  LFSMTransformer.onSync(nodeConfig.getClient, cache,
-                                    nodeConfig.getNodeWallet, stratumConfig.diff, syncedTrees, syncHandler, stateConfig.autoCommit.getOrElse(true))
-                                case NoRollups() =>
-                                  logger.info(s"Got NoRollups() state with 0 rollups")
-                              }
-
-                            }.recoverWith {
-                              case timeout: TimeoutException =>
-                                logger.warn("Skipping transforms due to no GetSynced response")
-                                Failure(timeout)
-                              case t: Throwable =>
-                                logger.error(s"Got error during transformations: ${t.getMessage} \n", t)
-                                Failure(t)
-                            }
-                          }
-                        }
-                    }(contexts.pollingContext)
+                  if(!stateConfig.disableTransforms.getOrElse(false)) {
+                    Try {
+                      implicit val timeout = Timeout(5 seconds)
+                      val msg = Await.result((syncHandler ? GetSynced).mapTo[SyncMessage], 5 seconds)
+                      msg match {
+                        case FullSync(nispTrees) =>
+                          logger.info(s"Got FullSync() state with ${nispTrees.size} rollups")
+                          LFSMTransformer.onSync(nodeConfig.getClient, cache,
+                            nodeConfig.getNodeWallet, stratumConfig.diff, nispTrees, syncHandler, stateConfig.autoCommit.getOrElse(true))
+                        case PartialSync(syncedTrees, unsyncedIds) =>
+                          logger.info(s"Got PartialSync() state with ${syncedTrees.size} synced rollups" +
+                            s" and ${unsyncedIds.size} unsynced rollups")
+                          LFSMTransformer.onSync(nodeConfig.getClient, cache,
+                            nodeConfig.getNodeWallet, stratumConfig.diff, syncedTrees, syncHandler, stateConfig.autoCommit.getOrElse(true))
+                        case NoRollups() =>
+                          logger.info(s"Got NoRollups() state with 0 rollups")
+                      }
+                    }.recoverWith {
+                      case timeout: TimeoutException =>
+                        logger.warn("Skipping transforms due to no GetSynced response")
+                        Failure(timeout)
+                      case t: Throwable =>
+                        logger.error(s"Got error during transformations: ${t.getMessage} \n", t)
+                        Failure(t)
+                    }
                   }
-//
               })(contexts.pollingContext)
               synced = true
             }
@@ -147,35 +136,7 @@ class RollupSyncTask @Inject()(cache: SyncCacheApi, system: ActorSystem, config:
 
   }
 
-  private def loadBlockAsync(height: Int, dataSource: NodeAndExplorerDataSourceImpl) = {
-    implicit val context: ExecutionContext = contexts.syncContext
-    Future {
-      if (height % 100 == 0)
-        logger.info(s"Loading block at height ${height}")
-      Try {
-
-        val blockHeader = dataSource
-          .getNodeBlocksApi.getFullBlockAt(height)
-          .execute()
-          .body().get(0)
-
-        val fullBlock = dataSource
-          .getNodeBlocksApi.getFullBlockById(blockHeader)
-          .execute()
-          .body()
-        awaitBlockSync(fullBlock)
-      }
-    }.map(_.get)
-
-  }
-
   private def checkBlockTransactions(block: FullBlock): Unit = {
     syncHandler ! BlockMessage(BlockInfo.fromSync(block))
-  }
-
-  private def awaitBlockSync(block: FullBlock) = {
-    implicit val timeout: Timeout = Timeout(7 seconds)
-
-    Await.result((syncHandler ? BlockMessage(BlockInfo.fromSync(block))).mapTo[HandledBlock], 7 seconds)
   }
 }


### PR DESCRIPTION
## Summary

- Introduces `StateFrame`, a new Akka actor that acts as the single source of block updates for all actors that have finished their initial blockchain sync.
- Replaces the independent per-task block-fetch polling loops in `RollupSyncTask` and `MDSyncTask` with a shared, interval-driven broadcaster.
- Adds `StateFrameMessages` (`Attach` / `Detach`) as the public API for subscribing actors.

## What changed

**`app/actors/StateFrame.scala`** (new)
Three-state actor — `idle` -> `running` -> `broadcasting`:
- Starts its scheduler lazily when the first subscriber sends `Attach`.
- On each `Tick`, fetches the next block and broadcasts `BlockMessage` to all subscribers via `ask`.
- Transitions to `broadcasting` immediately so subsequent `Tick`s are dropped while a round-trip is in flight.
- Sends itself `AdvanceHeight` once all `HandledBlock` acks (or timeouts) resolve, then returns to `running`.
- Cancels the scheduler and returns to `idle` when all subscribers detach.

**`app/state/messages/StateFrameMessages.scala`** (new)
Public `Attach(ref)` and `Detach(ref)` messages. `Tick` and `AdvanceHeight` are private to the `actors` package.

**`app/tasks/RollupSyncTask.scala`** / **`MDSyncTask.scala`** (modified)
After the initial catch-up loop completes:
1. `GetSynced` transitions the actor to its `postSync` state (which replies `HandledBlock`, satisfying StateFrame's ask pattern).
2. `Attach(actor)` is sent to StateFrame -- block delivery is now its sole responsibility.
3. The remaining schedule is transform-only: `RollupSyncTask` queries `GetSynced` and calls `LFSMTransformer.onSync()`; `MDSyncTask` checks for the data box token and calls `addToMD()`. The `loadBlockAsync` / `awaitBlockSync` methods are removed.

**`app/Module.scala`** (modified)
Binds `StateFrame` as `state-frame` on the same `lithos-contexts.sync-dispatcher` as the other sync actors.

## Reviewer notes

- The `broadcasting` state ensures at most one block is in flight at a time -- `Tick`s that arrive while waiting for acks are silently dropped and picked up on the next interval.
- If a subscriber times out on `HandledBlock`, `StateFrame` logs the error and advances height anyway to avoid stalling all other subscribers.
- `SyncHandler` and `MDSynchronizer` require no changes -- they already reply `HandledBlock` in their `postSync` states, which is exactly what StateFrame's ask expects.
- `LFSMTransformer.onSync()` / `addToMD()` remain in the tasks rather than moving into StateFrame, keeping the actor focused purely on block broadcasting.